### PR TITLE
Turret shots now get destroyed if they miss their target

### DIFF
--- a/game/Royale/Assets/Scripts/Tower.cs
+++ b/game/Royale/Assets/Scripts/Tower.cs
@@ -88,7 +88,7 @@ public class Tower : MonoBehaviour
     void Attack()
     {
         //Create a turret shot (check TowerShot.cs for bullet code).
-        GameObject towerShot = Instantiate(shotPrefab, transform.position, Quaternion.identity);
+        GameObject towerShot = Instantiate(shotPrefab, transform.position, Quaternion.identity, transform);
 
         // Passing the value for the target to the towershot
         TowerShot towerShotScript = towerShot.GetComponent<TowerShot>();

--- a/game/Royale/Assets/Scripts/TowerShot.cs
+++ b/game/Royale/Assets/Scripts/TowerShot.cs
@@ -16,7 +16,11 @@ public class TowerShot : MonoBehaviour
 
     void Update()
     {
-
+        //Incase the bullets miss their target, destory them based on distance to clear memory (20 can be played around with).
+        if (Vector2.Distance(transform.position, transform.parent.position) > 20)
+        {
+            Destroy(gameObject);
+        }
     }
 
     // Is called from the Tower.cs script when the TowerShot is instantiated. Set's the target for the shot


### PR DESCRIPTION
Turret shots now destroy if they miss their target based on a distance from the turret it was shot from

Merging into test to see if there are any conflicts before merging into main.