### PR TITLE
Amar cards attacking each other

### DIFF
--- a/game/Royale/Assets/Prefabs/P1Card.prefab
+++ b/game/Royale/Assets/Prefabs/P1Card.prefab
@@ -100,9 +100,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 200
+  currentHealth: 0
   moveSpeed: 3
   playerNum: 1
   attackCooldown: 5
+  attackCooldownTimer: 0
   attackDamage: 50
 --- !u!50 &5217164988416486184
 Rigidbody2D:
@@ -165,4 +167,4 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.6

--- a/game/Royale/Assets/Prefabs/P1Card.prefab
+++ b/game/Royale/Assets/Prefabs/P1Card.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36e7776770a26824fa237d7ec30143b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 200
+  maxHealth: 300
   currentHealth: 0
   moveSpeed: 3
   playerNum: 1

--- a/game/Royale/Assets/Prefabs/P2Card.prefab
+++ b/game/Royale/Assets/Prefabs/P2Card.prefab
@@ -100,9 +100,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealth: 200
+  currentHealth: 0
   moveSpeed: 3
   playerNum: 2
   attackCooldown: 5
+  attackCooldownTimer: 0
   attackDamage: 50
 --- !u!50 &5217164988416486184
 Rigidbody2D:
@@ -165,4 +167,4 @@ CircleCollider2D:
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
-  m_Radius: 0.5
+  m_Radius: 0.6

--- a/game/Royale/Assets/Prefabs/P2Card.prefab
+++ b/game/Royale/Assets/Prefabs/P2Card.prefab
@@ -99,7 +99,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36e7776770a26824fa237d7ec30143b5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxHealth: 200
+  maxHealth: 150
   currentHealth: 0
   moveSpeed: 3
   playerNum: 2

--- a/game/Royale/Assets/Scripts/Enemy.cs
+++ b/game/Royale/Assets/Scripts/Enemy.cs
@@ -140,41 +140,44 @@ public class Enemy : MonoBehaviour
     // Collision detection with tower - targeting system for attacking, and movement stopping
     void OnTriggerEnter2D(Collider2D collision)
     {
-        // Tower targeting and movement stopping
-        if (collision.gameObject.CompareTag("Tower"))
+        if (!isAttacking)
         {
-
-            // Implement the same logic in the enemy targeting to ensure troops can never attack their own tower
-            Tower tower = collision.gameObject.GetComponent<Tower>();
-            if (tower.playerNum != this.playerNum)
+            // Tower targeting and movement stopping
+            if (collision.gameObject.CompareTag("Tower"))
             {
-                attackTargetComponent = collision.gameObject.GetComponent<Tower>(); // Set the attack target to the tower
 
-                rb.velocity = Vector2.zero; // Stop the enemy when it collides with the tower
-                isMoving = false; // Stop movement when colliding with a tower
+                // Implement the same logic in the enemy targeting to ensure troops can never attack their own tower
+                Tower tower = collision.gameObject.GetComponent<Tower>();
+                if (tower.playerNum != this.playerNum)
+                {
+                    attackTargetComponent = collision.gameObject.GetComponent<Tower>(); // Set the attack target to the tower
 
-                isAttacking = true;
-                Debug.Log("Enemy stopping at tower");
+                    rb.velocity = Vector2.zero; // Stop the enemy when it collides with the tower
+                    isMoving = false; // Stop movement when colliding with a tower
+
+                    isAttacking = true;
+                    Debug.Log("Enemy stopping at tower");
+                }
+
             }
 
-        }
-
-        // Enemy troop targeting  
-        else if (collision.gameObject.CompareTag("Enemy"))
-        {
-            // Check if it is an opposing player troop before setting them as an attackTarget.
-            Enemy enemy = collision.gameObject.GetComponent<Enemy>();
-            if (enemy.playerNum != this.playerNum)
+            // Enemy troop targeting  
+            else if (collision.gameObject.CompareTag("Enemy"))
             {
-                attackTargetComponent = collision.gameObject.GetComponent<Enemy>(); // Set the attack target to the enemy
+                // Check if it is an opposing player troop before setting them as an attackTarget.
+                Enemy enemy = collision.gameObject.GetComponent<Enemy>();
+                if (enemy.playerNum != this.playerNum)
+                {
+                    attackTargetComponent = collision.gameObject.GetComponent<Enemy>(); // Set the attack target to the enemy
 
-                rb.velocity = Vector2.zero; // Stop the enemy when it collides with the other troop enemy
-                isMoving = false; // Stop movement when colliding with enemy
+                    rb.velocity = Vector2.zero; // Stop the enemy when it collides with the other troop enemy
+                    isMoving = false; // Stop movement when colliding with enemy
 
-                isAttacking = true;
-                Debug.Log("Enemy fighting a troop");
+                    isAttacking = true;
+                    Debug.Log("Enemy fighting a troop");
+                }
+
             }
-
         }
 
     }
@@ -191,6 +194,7 @@ public class Enemy : MonoBehaviour
 
             // Make the enemy start moving again
             isMoving = true;
+            FindAndMoveToNewTarget();
 
             Debug.Log("Enemy target lost");
         }
@@ -208,6 +212,9 @@ public class Enemy : MonoBehaviour
             {
                 Debug.Log("Enemy attacking tower");
                 tower.TakeDamage(attackDamage);
+
+                // Check if the tower has been defeated
+                targetDefeated = tower.health <= 0;
             }
 
             // Attack enemy troops
@@ -231,6 +238,8 @@ public class Enemy : MonoBehaviour
         // Check if the current attack target is still valid
         if (attackTargetComponent == null || attackTargetComponent.gameObject == null || targetDefeated)
         {
+            attackTargetComponent = null; // Clear the target if it's defeated
+            isAttacking = false; // Stop attacking mode
             FindAndMoveToNewTarget();
         }
     }
@@ -257,10 +266,12 @@ public class Enemy : MonoBehaviour
         if (target != null)
         {
             isMoving = true; // Resume movement if a new target is found
+            UpdateMovementTowardsTarget();
             Debug.Log("Moving to new target");
         }
         else
         {
+            rb.velocity = Vector2.zero;
             isMoving = false; // Stay put if no new target is available
             Debug.Log("No new targets available");
         }

--- a/game/Royale/Assets/Scripts/Enemy.cs
+++ b/game/Royale/Assets/Scripts/Enemy.cs
@@ -143,6 +143,9 @@ public class Enemy : MonoBehaviour
         // Tower targeting and movement stopping
         if (collision.gameObject.CompareTag("Tower"))
         {
+
+            // Implement the same logic in the enemy targeting to ensure troops can never attack their own tower
+
             attackTargetComponent = collision.gameObject.GetComponent<Tower>(); // Set the attack target to the tower
 
             rb.velocity = Vector2.zero; // Stop the enemy when it collides with the tower
@@ -155,13 +158,19 @@ public class Enemy : MonoBehaviour
         // Enemy troop targeting  
         else if (collision.gameObject.CompareTag("Enemy"))
         {
-            attackTargetComponent = collision.gameObject.GetComponent<Enemy>(); // Set the attack target to the enemy
+            // Check if it is an opposing player troop before setting them as an attackTarget.
+            Enemy enemy = collision.gameObject.GetComponent<Enemy>();
+            if (enemy.playerNum != this.playerNum)
+            {
+                attackTargetComponent = collision.gameObject.GetComponent<Enemy>(); // Set the attack target to the enemy
 
-            rb.velocity = Vector2.zero; // Stop the enemy when it collides with the other troop enemy
-            isMoving = false; // Stop movement when colliding with enemy
+                rb.velocity = Vector2.zero; // Stop the enemy when it collides with the other troop enemy
+                isMoving = false; // Stop movement when colliding with enemy
 
-            isAttacking = true;
-            Debug.Log("Enemy fighting a troop");
+                isAttacking = true;
+                Debug.Log("Enemy fighting a troop");
+            }
+
         }
 
     }

--- a/game/Royale/Assets/Scripts/Enemy.cs
+++ b/game/Royale/Assets/Scripts/Enemy.cs
@@ -145,14 +145,18 @@ public class Enemy : MonoBehaviour
         {
 
             // Implement the same logic in the enemy targeting to ensure troops can never attack their own tower
+            Tower tower = collision.gameObject.GetComponent<Tower>();
+            if (tower.playerNum != this.playerNum)
+            {
+                attackTargetComponent = collision.gameObject.GetComponent<Tower>(); // Set the attack target to the tower
 
-            attackTargetComponent = collision.gameObject.GetComponent<Tower>(); // Set the attack target to the tower
+                rb.velocity = Vector2.zero; // Stop the enemy when it collides with the tower
+                isMoving = false; // Stop movement when colliding with a tower
 
-            rb.velocity = Vector2.zero; // Stop the enemy when it collides with the tower
-            isMoving = false; // Stop movement when colliding with a tower
+                isAttacking = true;
+                Debug.Log("Enemy stopping at tower");
+            }
 
-            isAttacking = true;
-            Debug.Log("Enemy stopping at tower");
         }
 
         // Enemy troop targeting  

--- a/game/Royale/Assets/Scripts/Enemy.cs
+++ b/game/Royale/Assets/Scripts/Enemy.cs
@@ -56,13 +56,8 @@ public class Enemy : MonoBehaviour
             Attack();
         }
 
-        // Check if the target exists
-        if (target != null)
-        {
-            // Decrement the cooldown timer
-
-        }
-        else
+        // If no current tower target exists
+        if (target == null)
         {
             // If there's no current target, find a new one
             target = FindNearestTower();
@@ -71,6 +66,7 @@ public class Enemy : MonoBehaviour
                 // Optionally handle the case where there are no more towers
                 rb.velocity = Vector2.zero; // Stop moving if there are no targets
             }
+
         }
     }
 
@@ -159,24 +155,6 @@ public class Enemy : MonoBehaviour
 
     }
 
-    /*
-    void OnTriggerStay2D(Collider2D collision)
-    {
-        if (collision.gameObject.CompareTag("Tower") && attackCooldownTimer <= 0)
-        {
-            rb.velocity = Vector2.zero;
-            isMoving = false; // Stop movement when colliding with a tower
-
-            Tower tower = collision.gameObject.GetComponent<Tower>();
-            if (tower != null)
-            {
-                Debug.Log("Enemy attacking tower");
-                tower.TakeDamage(attackDamage); // Deal damage to the tower
-                attackCooldownTimer = attackCooldown; // Reset the attack cooldown timer
-            }
-        }
-    }
-    */
 
     // When the enemy kills the target, and it's collider disappears
     void OnTriggerExit2D(Collider2D collision)
@@ -193,6 +171,7 @@ public class Enemy : MonoBehaviour
         }
     }
 
+    // Replaced the OnTriggerStay2D. There were collider issues, so I moved attacking into it's own function.
     private void Attack()
     {
         if (attackTargetComponent != null)


### PR DESCRIPTION
- Enemies stop moving when attacking
- Enemies attack each other
- Enemies won't attack their own teammates
- Enemies won't attack their own towers should they come across them somehow
- Single enemy targeting is implemented so one troop won't defeat multiple.

There is a bug left to be fixed:
- If there is a 2v1 scenario, after that 1 kills one of the others, it decides to go to a tower instead of dealing with the one in front of them. I believe it is because of how the OnTriggerEnter is set up